### PR TITLE
Add type annotations to example code block

### DIFF
--- a/courses/mypy-primer/introduction/using-mypy.md
+++ b/courses/mypy-primer/introduction/using-mypy.md
@@ -81,7 +81,7 @@ Let's fix that:
     ></span>
 
 ```{#mypy3 .python .example .mypy-strict}
-def greet(name):
+def greet(name: str) -> None:
     print(f"Hello, {name}!")
 
 if __name__ == '__main__':


### PR DESCRIPTION
The code snippet in that code block wasn't the right one.